### PR TITLE
Make willSubmit handler async and support cancellation

### DIFF
--- a/packages/form/src/form.test.ts
+++ b/packages/form/src/form.test.ts
@@ -395,7 +395,7 @@ describe("Form", () => {
       const form = Form.get(model);
       const internal = debugForm(form);
       const spy = vi.spyOn(internal.submission, "addHandler");
-      expect(form.addHandler("willSubmit", () => void 0)).toBeInstanceOf(Function);
+      expect(form.addHandler("willSubmit", async () => true)).toBeInstanceOf(Function);
       expect(form.addHandler("submit", async () => false)).toBeInstanceOf(Function);
       expect(form.addHandler("didSubmit", () => void 0)).toBeInstanceOf(Function);
       expect(spy).toBeCalledTimes(3);

--- a/packages/form/src/submission.test.ts
+++ b/packages/form/src/submission.test.ts
@@ -8,8 +8,9 @@ describe("Submission", () => {
       const submission = new Submission();
       const timeline: string[] = [];
 
-      submission.addHandler("willSubmit", () => {
+      submission.addHandler("willSubmit", async () => {
         timeline.push("willSubmit 1");
+        return true;
       });
       submission.addHandler("submit", async () => {
         timeline.push("submit 1");
@@ -18,8 +19,9 @@ describe("Submission", () => {
       submission.addHandler("didSubmit", () => {
         timeline.push("didSubmit 1");
       });
-      submission.addHandler("willSubmit", () => {
+      submission.addHandler("willSubmit", async () => {
         timeline.push("willSubmit 2");
+        return true;
       });
       submission.addHandler("submit", async () => {
         timeline.push("submit 2");
@@ -50,8 +52,9 @@ describe("Submission", () => {
         timeline.push(`isRunning: ${submission.isRunning}`);
       });
 
-      submission.addHandler("willSubmit", () => {
+      submission.addHandler("willSubmit", async () => {
         timeline.push("willSubmit");
+        return true;
       });
       submission.addHandler("submit", async () => {
         timeline.push("submit");
@@ -65,11 +68,47 @@ describe("Submission", () => {
       expect(timeline).toMatchInlineSnapshot(`
         [
           "isRunning: false",
-          "willSubmit",
           "isRunning: true",
+          "willSubmit",
           "submit",
           "didSubmit",
           "isRunning: false",
+        ]
+      `);
+    });
+
+    it("processes willSubmit handlers serially regardless of timing", async () => {
+      const submission = new Submission();
+      const timeline: string[] = [];
+
+      submission.addHandler("willSubmit", async () => {
+        timeline.push("willSubmit 1 start");
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        timeline.push("willSubmit 1 end");
+        return true;
+      });
+      submission.addHandler("willSubmit", async () => {
+        timeline.push("willSubmit 2 start");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        timeline.push("willSubmit 2 end");
+        return true;
+      });
+      submission.addHandler("willSubmit", async () => {
+        timeline.push("willSubmit 3 start");
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        timeline.push("willSubmit 3 end");
+        return true;
+      });
+
+      await submission.exec();
+      expect(timeline).toMatchInlineSnapshot(`
+        [
+          "willSubmit 1 start",
+          "willSubmit 1 end",
+          "willSubmit 2 start",
+          "willSubmit 2 end",
+          "willSubmit 3 start",
+          "willSubmit 3 end",
         ]
       `);
     });
@@ -122,31 +161,51 @@ describe("Submission", () => {
 
     it("returns false when any submit handler fails and stops execution", async () => {
       const submission = new Submission();
-      const firsthandler = vi.fn(async () => true);
-      const secondhandler = vi.fn(async () => false);
-      const thirdhandler = vi.fn(async () => true);
+      const firstHandler = vi.fn(async () => true);
+      const secondHandler = vi.fn(async () => false);
+      const thirdHandler = vi.fn(async () => true);
 
-      submission.addHandler("submit", firsthandler);
-      submission.addHandler("submit", secondhandler);
-      submission.addHandler("submit", thirdhandler);
+      submission.addHandler("submit", firstHandler);
+      submission.addHandler("submit", secondHandler);
+      submission.addHandler("submit", thirdHandler);
 
       const result = await submission.exec();
       expect(result).toBe(false);
-      expect(firsthandler).toHaveBeenCalled();
-      expect(secondhandler).toHaveBeenCalled();
-      expect(thirdhandler).not.toHaveBeenCalled();
+      expect(firstHandler).toHaveBeenCalled();
+      expect(secondHandler).toHaveBeenCalled();
+      expect(thirdHandler).not.toHaveBeenCalled();
+    });
+
+    it("skips submit handlers when willSubmit returns false", async () => {
+      const submission = new Submission();
+      const willSubmitHandler1 = vi.fn(async () => true);
+      const willSubmitHandler2 = vi.fn(async () => false);
+      const willSubmitHandler3 = vi.fn(async () => true);
+      const submitHandler = vi.fn(async () => true);
+
+      submission.addHandler("willSubmit", willSubmitHandler1);
+      submission.addHandler("willSubmit", willSubmitHandler2);
+      submission.addHandler("willSubmit", willSubmitHandler3);
+      submission.addHandler("submit", submitHandler);
+
+      const result = await submission.exec();
+      expect(result).toBe(false);
+      expect(willSubmitHandler1).toHaveBeenCalled();
+      expect(willSubmitHandler2).toHaveBeenCalled();
+      expect(willSubmitHandler3).not.toHaveBeenCalled();
+      expect(submitHandler).not.toHaveBeenCalled();
     });
 
     it("handles errors in willSubmit handlers", async () => {
       const submission = new Submission();
-      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       submission.addHandler("willSubmit", () => {
         throw new Error("Test error");
       });
 
       const result = await submission.exec();
-      expect(result).toBe(true);
+      expect(result).toBe(false);
       expect(consoleSpy).toHaveBeenCalled();
     });
 

--- a/packages/form/src/submission.test.ts
+++ b/packages/form/src/submission.test.ts
@@ -200,7 +200,7 @@ describe("Submission", () => {
       const submission = new Submission();
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-      submission.addHandler("willSubmit", () => {
+      submission.addHandler("willSubmit", async () => {
         throw new Error("Test error");
       });
 


### PR DESCRIPTION
 This change allows willSubmit handlers to perform async  operations before submission and provides a way to  conditionally cancel the submission process.

- Changed willSubmit handler to be async and return
  Promise<boolean>
- Added abortSignal parameter to willSubmit handler
- Submission now fails if willSubmit handler throws an error
(previously continued)
- Changed error logging from console.warn to console.error for
 consistency
- Submission cancels if any willSubmit handler returns false
- Ensured willSubmit handlers execute serially
- Updated tests to verify new error handling behavior