### PR TITLE
Fix addHandler return type definition

### DIFF
--- a/packages/form/src/form.ts
+++ b/packages/form/src/form.ts
@@ -315,9 +315,9 @@ export class Form<T> {
    * @returns Function to remove the handler
    */
   addHandler: {
-    (event: "willSubmit", handler: Submission.Handlers["willSubmit"]): void;
-    (event: "submit", handler: Submission.Handlers["submit"]): void;
-    (event: "didSubmit", handler: Submission.Handlers["didSubmit"]): void;
+    (event: "willSubmit", handler: Submission.Handlers["willSubmit"]): () => void;
+    (event: "submit", handler: Submission.Handlers["submit"]): () => void;
+    (event: "didSubmit", handler: Submission.Handlers["didSubmit"]): () => void;
   } = (...args) => this.#submission.addHandler(...args);
 
   /**


### PR DESCRIPTION
The addHandler method returns a function to remove the handler, but the type definition incorrectly specified void as the return type.
This fix updates the return type to () => void to match the actual behavior.

- Changed from `void` to `() => void` to properly reflect that the method returns an unsubscribe
  function