### PR TITLE
Move @mobx-sentinel/* to peer deps

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,9 +38,9 @@
     "mobx": "^6.0.0"
   },
   "devDependencies": {
-    "mobx": "^6.12.3",
     "@types/node": "^22.10.2",
     "@vitest/coverage-v8": "^2.1.8",
+    "mobx": "^6.12.3",
     "tsup": "^8.3.5",
     "typescript": "^5.5.0",
     "vitest": "^2.1.8"

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -35,13 +35,14 @@
     "uuid": "^11.0.4"
   },
   "peerDependencies": {
-    "@mobx-sentinel/core": "workspace:*",
+    "@mobx-sentinel/core": "workspace:~",
     "mobx": "^6.0.0"
   },
   "devDependencies": {
-    "mobx": "^6.12.3",
+    "@mobx-sentinel/core": "workspace:~",
     "@types/node": "^22.10.2",
     "@vitest/coverage-v8": "^2.1.8",
+    "mobx": "^6.12.3",
     "tsup": "^8.3.5",
     "typescript": "^5.5.0",
     "vitest": "^2.1.8"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -44,13 +44,14 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@mobx-sentinel/form": "workspace:*",
+    "@mobx-sentinel/form": "workspace:~",
     "mobx": "^6.0.0",
     "mobx-react-lite": "^4.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@mobx-sentinel/form": "workspace:~",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,13 +121,13 @@ importers:
 
   packages/form:
     dependencies:
-      '@mobx-sentinel/core':
-        specifier: workspace:*
-        version: link:../core
       uuid:
         specifier: ^11.0.4
         version: 11.0.4
     devDependencies:
+      '@mobx-sentinel/core':
+        specifier: workspace:~
+        version: link:../core
       '@types/node':
         specifier: ^22.10.2
         version: 22.10.2
@@ -148,11 +148,10 @@ importers:
         version: 2.1.8(@types/node@22.10.2)(jsdom@25.0.1)
 
   packages/react:
-    dependencies:
-      '@mobx-sentinel/form':
-        specifier: workspace:*
-        version: link:../form
     devDependencies:
+      '@mobx-sentinel/form':
+        specifier: workspace:~
+        version: link:../form
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3


### PR DESCRIPTION
Since all `@mobx-sentinel/*` packages can be used independently, they should be listed as peer dependencies of one another.

Related: https://github.com/creasty/mobx-sentinel/pull/116